### PR TITLE
fix: Remove Editor library from package and replace with cs files

### DIFF
--- a/BuildUnityPackages.ps1
+++ b/BuildUnityPackages.ps1
@@ -1,9 +1,14 @@
-$libraryFiles = @("Sophia.Core.dll", "Sophia.Editor.dll", "Sophia.Platform.dll")
+$libraryFiles = @("Sophia.Core.dll", "Sophia.Platform.dll")
+
+$editorFiles = Get-ChildItem -Path "./Sophia.Editor/*.cs" -Recurse -Exclude "*AssemblyInfo.cs"
+$editorFiles = $editorFiles.FullName.Replace("\", "/")
 
 $myPath = (Get-Item -Path ".\").FullName;
 $myPath = $myPath.Replace("\", "/")
 
 $libraryBasePath = -join ($myPath, "/lib/")
+$editorBasePath = -join ($myPath, "/Sophia.Editor/")
+
 $builderPath = -join ($myPath, "/Libraries/UnityPackager/UnityPackager.exe")
 $packageOutPath = -join ($myPath, "/Sophia.unitypackage")
 
@@ -14,6 +19,12 @@ $libraryBuildArgs = -join ("null", " ", $packageOutPath, " ")
 For ($i=0; $i -lt $libraryFiles.Count; $i++)  
 {
     $libraryBuildArgs += -join ($libraryBasePath, $libraryFiles.Get($i), " ", "Assets/Plugins/Sophia/", $libraryFiles.Get($i), " ")
+}
+
+# Add editor files to library package under a different path
+For ($i=0; $i -lt $editorFiles.Count; $i++)  
+{
+    $libraryBuildArgs += -join ($editorFiles.Get($i), " ", "Assets/Editor/Sophia/", $editorFiles.Get($i).Replace($editorBasePath, ""), " ") 
 }
 
 Write-Host $builderPath


### PR DESCRIPTION
When a Unity project is build, the editor .dll has to be excluded manually to prevent build errors.
A cleaner solution is to use cs files instead.

Fixes #6